### PR TITLE
Remove auto versioning

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -3,11 +3,11 @@ author  = John Tate <jt6@sanger.ac.uk>
 license = GPL_3
 copyright_holder = Wellcome Trust Sanger Institute
 copyright_year   = 2015
+version = 0.1.0
 
 [@Git]
 [@Starter]
 [AutoPrereqs]
-[AutoVersion]
 [PodWeaver]
 
 [Encoding]


### PR DESCRIPTION
Removing auto versioning and adding manual versioning so that Perl builds can be added to the release for use with conda.